### PR TITLE
Added gulp-cli as local dev dependency

### DIFF
--- a/howto-gallery/package-lock.json
+++ b/howto-gallery/package-lock.json
@@ -15,6 +15,7 @@
         "@types/mojang-net": "^0.1.0",
         "del": "^6.0.0",
         "gulp": "^4.0.2",
+        "gulp-cli": "^2.3.0",
         "gulp-sourcemaps": "^3.0.0",
         "gulp-typescript": "^6.0.0-alpha.1",
         "typescript": "^4.4.3"

--- a/howto-gallery/package.json
+++ b/howto-gallery/package.json
@@ -9,6 +9,7 @@
     "@types/mojang-minecraft": "^0.1.3",
     "del": "^6.0.0",
     "gulp": "^4.0.2",
+    "gulp-cli": "^2.3.0",
     "gulp-sourcemaps": "^3.0.0",
     "gulp-typescript": "^6.0.0-alpha.1",
     "typescript": "^4.4.3",

--- a/ts-starter/package-lock.json
+++ b/ts-starter/package-lock.json
@@ -12,6 +12,7 @@
         "@types/mojang-minecraft": "^0.1.3",
         "del": "^6.0.0",
         "gulp": "^4.0.2",
+        "gulp-cli": "^2.3.0",
         "gulp-sourcemaps": "^3.0.0",
         "gulp-typescript": "^6.0.0-alpha.1",
         "typescript": "^4.4.3"

--- a/ts-starter/package.json
+++ b/ts-starter/package.json
@@ -9,6 +9,7 @@
     "@types/mojang-minecraft": "^0.1.3",
     "del": "^6.0.0",
     "gulp": "^4.0.2",
+    "gulp-cli": "^2.3.0",
     "gulp-typescript": "^6.0.0-alpha.1",
     "typescript": "^4.4.3",
     "gulp-sourcemaps": "^3.0.0"


### PR DESCRIPTION
Installing global dependencies is bad practice since `npx` has been released.

More info on the [npm website](https://stackoverflow.com/a/22115441) and [stack overflow](https://stackoverflow.com/a/22115441).

With these changes, you can run `npx gulp` at the root of the project. Optionally, you can add a `build` script to the `package.json` file.