### PR TITLE
Fixed module type

### DIFF
--- a/howto-gallery/behavior_packs/howto-gallery/manifest.json
+++ b/howto-gallery/behavior_packs/howto-gallery/manifest.json
@@ -10,7 +10,8 @@
   "modules": [
     {
       "description": "Script resources",
-      "type": "javascript",
+      "type": "script",
+      "language": "javascript",
       "uuid": "df6523d1-4442-45c2-b33a-1c882d388683",
       "version": [0, 0, 1],
       "entry": "scripts/main.js"


### PR DESCRIPTION
I tried this example but got an import error. This change fixed it.

The documentation is also wrong: https://docs.microsoft.com/en-us/minecraft/creator/reference/content/addonsreference/examples/addonmanifest#modules