### PR TITLE
Fix erroneous declaration spelling for `bracketSpacing`.

### DIFF
--- a/ts-starter/.prettierrc.json
+++ b/ts-starter/.prettierrc.json
@@ -4,7 +4,7 @@
     "semi": true,
     "singleQuote": false,
     "tabs": false,
-    "backetSpacing": true,
+    "bracketSpacing": true,
     "arrowParens": "always",
     "printWidth": 120
   }


### PR DESCRIPTION
Changed from `backetSpacing` to `bracketSpacing`