### PR TITLE
Linting improvements

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-* text eol=crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=crlf

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,20 @@
+{
+    "eslint.experimental.useFlatConfig": true,
+    "eslint.workingDirectories": [
+        {
+            "pattern": "./build-challenge/*/"
+        },
+        {
+            "pattern": "./howto-gallery/*/"
+        },
+        {
+            "pattern": "./script-box/*/"
+        },
+        {
+            "pattern": "./ts-starter/*/"
+        },
+        {
+            "pattern": "./ts-starter-complete-cotta/*/"
+        },
+    ]
+}

--- a/build-challenge/.prettierrc.json
+++ b/build-challenge/.prettierrc.json
@@ -5,5 +5,6 @@
   "singleQuote": false,
   "bracketSpacing": true,
   "arrowParens": "always",
-  "printWidth": 120
+  "printWidth": 120,
+  "endOfLine": "auto"
 }

--- a/build-challenge/.prettierrc.json
+++ b/build-challenge/.prettierrc.json
@@ -6,5 +6,5 @@
   "bracketSpacing": true,
   "arrowParens": "always",
   "printWidth": 120,
-  "endOfLine": "auto"
+  "endOfLine": "crlf"
 }

--- a/build-challenge/.prettierrc.json
+++ b/build-challenge/.prettierrc.json
@@ -6,5 +6,5 @@
   "bracketSpacing": true,
   "arrowParens": "always",
   "printWidth": 120,
-  "endOfLine": "crlf"
+  "endOfLine": "auto"
 }

--- a/howto-gallery/.prettierrc.json
+++ b/howto-gallery/.prettierrc.json
@@ -5,5 +5,6 @@
   "singleQuote": false,
   "bracketSpacing": true,
   "arrowParens": "always",
-  "printWidth": 120
+  "printWidth": 120,
+  "endOfLine": "auto"
 }

--- a/howto-gallery/.prettierrc.json
+++ b/howto-gallery/.prettierrc.json
@@ -6,5 +6,5 @@
   "bracketSpacing": true,
   "arrowParens": "always",
   "printWidth": 120,
-  "endOfLine": "auto"
+  "endOfLine": "crlf"
 }

--- a/howto-gallery/.prettierrc.json
+++ b/howto-gallery/.prettierrc.json
@@ -6,5 +6,5 @@
   "bracketSpacing": true,
   "arrowParens": "always",
   "printWidth": 120,
-  "endOfLine": "crlf"
+  "endOfLine": "auto"
 }

--- a/script-box/.prettierrc.json
+++ b/script-box/.prettierrc.json
@@ -5,5 +5,6 @@
   "singleQuote": false,
   "bracketSpacing": true,
   "arrowParens": "always",
-  "printWidth": 120
+  "printWidth": 120,
+  "endOfLine": "auto"
 }

--- a/script-box/.prettierrc.json
+++ b/script-box/.prettierrc.json
@@ -6,5 +6,5 @@
   "bracketSpacing": true,
   "arrowParens": "always",
   "printWidth": 120,
-  "endOfLine": "auto"
+  "endOfLine": "crlf"
 }

--- a/script-box/.prettierrc.json
+++ b/script-box/.prettierrc.json
@@ -6,5 +6,5 @@
   "bracketSpacing": true,
   "arrowParens": "always",
   "printWidth": 120,
-  "endOfLine": "crlf"
+  "endOfLine": "auto"
 }

--- a/ts-starter-complete-cotta/.prettierrc.json
+++ b/ts-starter-complete-cotta/.prettierrc.json
@@ -5,5 +5,6 @@
   "singleQuote": false,
   "bracketSpacing": true,
   "arrowParens": "always",
-  "printWidth": 120
+  "printWidth": 120,
+  "endOfLine": "auto"
 }

--- a/ts-starter-complete-cotta/.prettierrc.json
+++ b/ts-starter-complete-cotta/.prettierrc.json
@@ -6,5 +6,5 @@
   "bracketSpacing": true,
   "arrowParens": "always",
   "printWidth": 120,
-  "endOfLine": "auto"
+  "endOfLine": "crlf"
 }

--- a/ts-starter-complete-cotta/.prettierrc.json
+++ b/ts-starter-complete-cotta/.prettierrc.json
@@ -6,5 +6,5 @@
   "bracketSpacing": true,
   "arrowParens": "always",
   "printWidth": 120,
-  "endOfLine": "crlf"
+  "endOfLine": "auto"
 }

--- a/ts-starter/.prettierrc.json
+++ b/ts-starter/.prettierrc.json
@@ -5,5 +5,6 @@
   "singleQuote": false,
   "bracketSpacing": true,
   "arrowParens": "always",
-  "printWidth": 120
+  "printWidth": 120,
+  "endOfLine": "auto"
 }

--- a/ts-starter/.prettierrc.json
+++ b/ts-starter/.prettierrc.json
@@ -6,5 +6,5 @@
   "bracketSpacing": true,
   "arrowParens": "always",
   "printWidth": 120,
-  "endOfLine": "auto"
+  "endOfLine": "crlf"
 }

--- a/ts-starter/.prettierrc.json
+++ b/ts-starter/.prettierrc.json
@@ -6,5 +6,5 @@
   "bracketSpacing": true,
   "arrowParens": "always",
   "printWidth": 120,
-  "endOfLine": "crlf"
+  "endOfLine": "auto"
 }


### PR DESCRIPTION
### Description

Adding some improvements over the ESLint checks:

- Enabling validations from Visual Studio Code when opening from root path (for flat config files).
 
![image](https://github.com/microsoft/minecraft-scripting-samples/assets/93944312/3dcb7430-be26-4700-88a1-0ccc2a2a3afb)

- Changing end of line check to auto. To avoid linting errors after pulling the repo due to end of line mismatches. Before and after using the new config:

![image](https://github.com/microsoft/minecraft-scripting-samples/assets/93944312/c3848aad-e1a9-46de-a5a9-bcc504e67cff)
